### PR TITLE
tar: Fix -t/-x desynchronization allowing hidden file injection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+tar (1.35+dfsg-3deepin1) unstable; urgency=medium
+
+  * Fix tar -t/-x desynchronization allowing hidden file injection
+    - When processing archive entries containing non-data types (symlink,
+      chardev, blockdev, FIFO) with non-zero size fields, tar -t would list
+      N entries but tar -x would actually extract N+M entries, allowing
+      hidden file injection attacks that bypass security review.
+    - Patch from upstream commit b8d8a61b25588caca4efaf9bdd2e3f1a49da77e3
+      by Paul Eggert.
+
+ -- hudeng <hudeng@deepin.org>   Wed, 09 Apr 2026 16:15:00 +0800
+
 tar (1.35+dfsg-3) unstable; urgency=medium
 
   [ Gianfranco Costamagna ]

--- a/debian/patches/fix-tx-desync-hidden-file-injection.patch
+++ b/debian/patches/fix-tx-desync-hidden-file-injection.patch
@@ -1,0 +1,337 @@
+diff --git a/src/extract.c b/src/extract.c
+index 314d8bc0..59abef0b 100644
+--- a/src/extract.c
++++ b/src/extract.c
+@@ -1037,7 +1037,7 @@ safe_dir_mode (struct stat const *st)
+ /* Extractor functions for various member types */
+ 
+ static int
+-extract_dir (char *file_name, int typeflag)
++extract_dir (char *file_name, MAYBE_UNUSED int typeflag)
+ {
+   int status;
+   mode_t mode;
+@@ -1060,8 +1060,6 @@ extract_dir (char *file_name, int typeflag)
+   if (incremental_option)
+     /* Read the entry and delete files that aren't listed in the archive.  */
+     purge_directory (file_name);
+-  else if (typeflag == GNUTYPE_DUMPDIR)
+-    skip_member ();
+ 
+   mode = safe_dir_mode (&current_stat_info.stat);
+ 
+@@ -1266,10 +1264,7 @@ extract_file (char *file_name, int typeflag)
+     {
+       fd = sys_exec_command (file_name, 'f', &current_stat_info);
+       if (fd < 0)
+-	{
+-	  skip_member ();
+-	  return 0;
+-	}
++	return 0;
+     }
+   else
+     {
+@@ -1289,7 +1284,6 @@ extract_file (char *file_name, int typeflag)
+ 	  int recover = maybe_recoverable (file_name, true, &interdir_made);
+ 	  if (recover != RECOVER_OK)
+ 	    {
+-	      skip_member ();
+ 	      if (recover == RECOVER_SKIP)
+ 		return 0;
+ 	      open_error (file_name);
+@@ -1337,6 +1331,7 @@ extract_file (char *file_name, int typeflag)
+       }
+ 
+   skim_file (size, false);
++  current_stat_info.skipped = true;
+ 
+   mv_end ();
+ 
+@@ -1844,15 +1839,10 @@ extract_archive (void)
+   typeflag = sparse_member_p (&current_stat_info) ?
+                   GNUTYPE_SPARSE : current_header->header.typeflag;
+ 
+-  if (prepare_to_extract (current_stat_info.file_name, typeflag, &fun))
+-    {
+-      if (fun (current_stat_info.file_name, typeflag) == 0)
+-	return;
+-    }
+-  else
+-    skip_member ();
+-
+-  if (backup_option)
++  bool ok = prepare_to_extract (current_stat_info.file_name, typeflag, &fun)
++	    && fun (current_stat_info.file_name, typeflag) == 0;
++  skip_member ();
++  if (!ok && backup_option)
+     undo_last_backup ();
+ }
+ 
+diff --git a/src/incremen.c b/src/incremen.c
+index 7bcfdb93..a6454b93 100644
+--- a/src/incremen.c
++++ b/src/incremen.c
+@@ -1154,7 +1154,7 @@ read_num (FILE *fp, char const *fieldname,
+ 	FATAL_ERROR ((0, 0, "%s: %s",
+ 		      quotearg_colon (listed_incremental_option),
+ 		      _("Unexpected EOF in snapshot file")));
+-      return false;
++      return;
+     }
+ 
+   if (c)
+@@ -1560,7 +1560,7 @@ dumpdir_ok (char *dumpdir)
+ 	    {
+ 	      ERROR ((0, 0,
+ 		      _("Malformed dumpdir: 'X' duplicated")));
+-	      return false;
++	      return;
+ 	    }
+ 	  else
+ 	    has_tempdir = 1;
+@@ -1586,13 +1586,13 @@ dumpdir_ok (char *dumpdir)
+ 	    {
+ 	      ERROR ((0, 0,
+ 		      _("Malformed dumpdir: 'T' not preceded by 'R'")));
+-	      return false;
++	      return;
+ 	    }
+ 	  if (p[1] == 0 && !has_tempdir)
+ 	    {
+ 	      ERROR ((0, 0,
+ 		      _("Malformed dumpdir: empty name in 'T'")));
+-	      return false;
++	      return;
+ 	    }
+ 	  expect = 0;
+ 	  break;
+@@ -1613,7 +1613,7 @@ dumpdir_ok (char *dumpdir)
+       ERROR ((0, 0,
+ 	      _("Malformed dumpdir: expected '%c' but found end of data"),
+ 	      expect));
+-      return false;
++      return;
+     }
+ 
+   if (has_tempdir)
+@@ -1625,8 +1625,8 @@ dumpdir_ok (char *dumpdir)
+ 
+ /* Examine the directories under directory_name and delete any
+    files that were not there at the time of the back-up. */
+-static bool
+-try_purge_directory (char const *directory_name)
++void
++purge_directory (char const *directory_name)
+ {
+   char *current_dir;
+   char *cur, *arc, *p;
+@@ -1634,18 +1634,18 @@ try_purge_directory (char const *directory_name)
+   struct dumpdir *dump;
+ 
+   if (!is_dumpdir (&current_stat_info))
+-    return false;
++    return;
+ 
+   current_dir = tar_savedir (directory_name, 0);
+ 
+   if (!current_dir)
+     /* The directory doesn't exist now.  It'll be created.  In any
+        case, we don't have to delete any files out of it.  */
+-    return false;
++    return;
+ 
+   /* Verify if dump directory is sane */
+   if (!dumpdir_ok (current_stat_info.dumpdir))
+-    return false;
++    return;
+ 
+   /* Process renames */
+   for (arc = current_stat_info.dumpdir; *arc; arc += strlen (arc) + 1)
+@@ -1666,7 +1666,7 @@ try_purge_directory (char const *directory_name)
+ 		      quote (temp_stub)));
+ 	      free (temp_stub);
+ 	      free (current_dir);
+-	      return false;
++	      return;
+ 	    }
+ 	}
+       else if (*arc == 'R')
+@@ -1700,7 +1700,7 @@ try_purge_directory (char const *directory_name)
+ 	      free (current_dir);
+ 	      /* FIXME: Make sure purge_directory(dst) will return
+ 		 immediately */
+-	      return false;
++	      return;
+ 	    }
+ 	}
+     }
+@@ -1758,14 +1758,6 @@ try_purge_directory (char const *directory_name)
+   dumpdir_free (dump);
+ 
+   free (current_dir);
+-  return true;
+-}
+-
+-void
+-purge_directory (char const *directory_name)
+-{
+-  if (!try_purge_directory (directory_name))
+-    skip_member ();
+ }
+ 
+ void
+diff --git a/src/list.c b/src/list.c
+index e9a68159..c9623eb4 100644
+--- a/src/list.c
++++ b/src/list.c
+@@ -437,20 +437,15 @@ read_header (union block **return_block, struct tar_stat_info *info,
+       if ((status = tar_checksum (header, false)) != HEADER_SUCCESS)
+ 	break;
+ 
+-      /* Good block.  Decode file size and return.  */
+-
+-      if (header->header.typeflag == LNKTYPE)
+-	info->stat.st_size = 0;	/* links 0 size on tape */
+-      else
++      info->stat.st_size = OFF_FROM_HEADER (header->header.size);
++      if (info->stat.st_size < 0)
+ 	{
+-	  info->stat.st_size = OFF_FROM_HEADER (header->header.size);
+-	  if (info->stat.st_size < 0)
+-	    {
+-	      status = HEADER_FAILURE;
+-	      break;
+-	    }
++	  status = HEADER_FAILURE;
++	  break;
+ 	}
+ 
++      info->skipped = false;
++
+       if (header->header.typeflag == GNUTYPE_LONGNAME
+ 	  || header->header.typeflag == GNUTYPE_LONGLINK
+ 	  || header->header.typeflag == XHDTYPE
+@@ -513,11 +508,15 @@ read_header (union block **return_block, struct tar_stat_info *info,
+ 		}
+ 
+ 	      *bp = '\0';
++	      info->skipped = true;
+ 	    }
+ 	  else if (header->header.typeflag == XHDTYPE
+ 		   || header->header.typeflag == SOLARIS_XHDTYPE)
+-	    xheader_read (&info->xhdr, header,
+-			  OFF_FROM_HEADER (header->header.size));
++	    {
++	      xheader_read (&info->xhdr, header,
++			    OFF_FROM_HEADER (header->header.size));
++	      info->skipped = true;
++	    }
+ 	  else if (header->header.typeflag == XGLTYPE)
+ 	    {
+ 	      struct xheader xhdr;
+@@ -531,6 +530,7 @@ read_header (union block **return_block, struct tar_stat_info *info,
+ 			    OFF_FROM_HEADER (header->header.size));
+ 	      xheader_decode_global (&xhdr);
+ 	      xheader_destroy (&xhdr);
++	      info->skipped = true;
+ 	      if (mode == read_header_x_global)
+ 		{
+ 		  status = HEADER_SUCCESS_EXTENDED;
+@@ -1447,17 +1447,17 @@ skim_member (bool must_copy)
+ {
+   if (!current_stat_info.skipped)
+     {
+-      char save_typeflag = current_header->header.typeflag;
+       set_next_block_after (current_header);
+ 
+       mv_begin_read (&current_stat_info);
+ 
+       if (current_stat_info.is_sparse)
+ 	sparse_skim_file (&current_stat_info, must_copy);
+-      else if (save_typeflag != DIRTYPE)
++      else
+ 	skim_file (current_stat_info.stat.st_size, must_copy);
+ 
+       mv_end ();
++      current_stat_info.skipped = true;
+     }
+ }
+ 
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 4a8f501f..0c75cd66 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -125,6 +125,7 @@ TESTSUITE_AT = \
+  extrac23.at\
+  extrac24.at\
+  extrac25.at\
++ extrac32.at\
+  filerem01.at\
+  filerem02.at\
+  dirrem01.at\
+diff --git a/tests/extrac32.at b/tests/extrac32.at
+new file mode 100644
+index 00000000..3829a483
+--- /dev/null
++++ b/tests/extrac32.at
+@@ -0,0 +1,47 @@
++# Check for file injection bug with symlinks. -*- Autotest -*-
++
++# Copyright 2026 Free Software Foundation, Inc.
++
++# This file is part of GNU tar.
++
++# GNU tar is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++
++# GNU tar is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++# Thanks to Guillermo de Angel for the bug report and test cases; see:
++# https://lists.gnu.org/r/bug-tar/2026-03/msg00007.html
++
++AT_SETUP([skip file injection])
++AT_KEYWORDS([injection])
++AT_DATA([archive.in],
++[/Td6WFoAAATm1rRGBMDbAYAcIQEcAAAAAAAAACYr+9LgDf8A010AMZhKvfVdtHe4Rxjj7M03ek97
++UgeKfJ0ORqYg0XDFntWxdTH4PYrTOo9CoqBrnTM2NcwFBrRVr7aFwdd56vddyAw2QGDjxgNexDU3
++ImTi/+z8ZOLMi/+AybdEpd5aA/M9Maa+8tQ84bySzSAwrmxMWJJ6W9IKvsqfiRa3TrD51v44PZU/
++KLVKpocS56n/O3g+b+hiZwaysR0eLO+tiU8FB/e3PEq3vTtDFVi/YfZMieBWSzomSX9eF13K1yPY
++UuWgp7VokXqduL0YGNVV40MTPG9oAAAApD6mpajengIAAfcBgBwAAOM4xw6xxGf7AgAAAAAEWVo=
++])
++AT_CHECK([base64 --help >/dev/null 2>&1 || AT_SKIP_TEST
++xz --help >/dev/null 2>&1 || AT_SKIP_TEST
++base64 -d < archive.in | xz -c -d > archive.tar
++])
++cp archive.tar /tmp
++AT_CHECK([tar tf archive.tar],
++[0],
++[carrier_entry
++marker.txt
++])
++AT_CHECK([tar xvf archive.tar],
++[0],
++[carrier_entry
++marker.txt
++])
++AT_CLEANUP
+diff --git a/tests/testsuite.at b/tests/testsuite.at
+index 44ae773b..77df3321 100644
+--- a/tests/testsuite.at
++++ b/tests/testsuite.at
+@@ -349,6 +349,7 @@ m4_include([extrac22.at])
+ m4_include([extrac23.at])
+ m4_include([extrac24.at])
+ m4_include([extrac25.at])
++m4_include([extrac32.at])
+ 
+ m4_include([backup01.at])
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ oldgnu-unknown-mode-bits.patch
 proper_it_translation.patch
 exclude17.patch
 exclude18.patch
+fix-tx-desync-hidden-file-injection.patch


### PR DESCRIPTION
## 修复内容

修复 GNU tar 1.35 中 `-t`/`-x` 不同步导致的隐藏文件注入漏洞。

当处理包含非数据类型（symlink、chardev、blockdev、FIFO）且 size 字段非零的归档条目时，`tar -t` 列出 N 个文件但 `tar -x` 实际提取更多文件，允许攻击者绕过安全审查注入隐藏文件。

## 上游修复来源

**Upstream:** https://git.savannah.gnu.org/cgit/tar.git/commit/?id=b8d8a61b25588caca4efaf9bdd2e3f1a49da77e3

- 作者：Paul Eggert
- 披露讨论：https://lists.gnu.org/r/bug-tar/2026-03/msg00007.html

## 变更文件

- `debian/patches/fix-tx-desync-hidden-file-injection.patch`（新增）
- `debian/patches/series`（追加新补丁）
- `debian/changelog`（版本更新为 `1.35+dfsg-3deepin1`）
